### PR TITLE
[MINOR] Update comment in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ COPY requirements.txt /workspace
 RUN pip install -r requirements.txt
 
 COPY . /workspace
-RUN md5sum -c md5sums.txt # check file integrity
+
+# check file integrity
+RUN md5sum -c md5sums.txt
 
 EXPOSE 5000
 


### PR DESCRIPTION
`RUN md5sum -c md5sums.txt # check file integrity` is incorrect. A comment must start at the beginning of a line otherwise it is treated as an argument.

https://docs.docker.com/engine/reference/builder/