### PR TITLE
Support pre-trained and custom-trained model assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ WORKDIR /workspace
 ARG use_pre_trained_model=true
 
 RUN if [ "$use_pre_trained_model" = "true" ] ; then\
-    # download pre-trained model artifacts from Cloud Object Storage
-    wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=assets/${model_file} &&\
-            tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file} ; fi
+     # download pre-trained model artifacts from Cloud Object Storage
+     wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=assets/${model_file} &&\
+     tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file} ; \
+    fi
 
 COPY requirements.txt /workspace
 RUN pip install -r requirements.txt
@@ -23,8 +24,8 @@ RUN if [ "$use_pre_trained_model" = "true" ] ; then \
       md5sum -c md5sums.txt ; \
     else \
       # rename the directory that contains the custom-trained model artifacts
-      if [ -d "/workspace/custom_assets/" ] ; then \
-        mv /workspace/custom_assets/* /workspace/assets ; \
+      if [ -d "./custom_assets/" ] ; then \
+        rm -rf ./assets && ln -s ./custom_assets ./assets ; \
       fi \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,27 @@ FROM codait/max-base:v1.1.3
 
 WORKDIR /workspace
 
-RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=assets/${model_file} && \
-  tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
+ARG use_pre_trained_model=true
+
+RUN if [ "$use_pre_trained_model" = "true" ] ; then\
+    # download pre-trained model artifacts from Cloud Object Storage
+    wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=assets/${model_file} &&\
+            tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file} ; fi
 
 COPY requirements.txt /workspace
 RUN pip install -r requirements.txt
 
 COPY . /workspace
 
-# check file integrity
-RUN md5sum -c md5sums.txt
+RUN if [ "$use_pre_trained_model" = "true" ] ; then \
+      # validate downloaded pre-trained model assets
+      md5sum -c md5sums.txt ; \
+    else \
+      # rename the directory that contains the custom-trained model artifacts
+      if [ -d "/workspace/custom_assets/" ] ; then \
+        mv /workspace/custom_assets/* /workspace/assets ; \
+      fi \
+    fi
 
 EXPOSE 5000
 


### PR DESCRIPTION
In support of model training the changed `Dockerfile` now performs the follow steps:

if build argument `use_pre_trained_model` is set to `true` (default if not specified):
 - downloads pre-trained model assets from Cloud Object Storage to the `assets/` directory
 - validates that the MD5 hash of the downloaded assets matches the expected MD5 hash
 - Example invocations:
   ```
    $ docker build -t max-object-detector  .
    $ docker build -t max-object-detector --build-arg use_pre_trained_model=true .
   ```

if build argument `use_pre_trained_model` is set to `false`:
 - copies the pre-trained model assets from the `custom_assets` directory to the `assets/` directory (the training job stores the custom-trained assets in the `custom_assets` directory
 - Example invocation:
   ```
    $ docker build -t max-object-detector --build-arg use_pre_trained_model=false .
   ```


Closes #16 