### PR TITLE
Remove references to assets/ directory

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -10,7 +10,7 @@ Most sections that need to be updated are either marked in brackets or reference
 Some helpful hints are also included in comment blocks like this one. Please remember to delete the 
 comment blocks before publishing.
 
-> Don't forget to update `assets/README.md` and `samples/README.md` as well.
+> Don't forget to update `samples/README.md` as well.
 
 This repository contains code to instantiate and deploy a [MODEL NAME].
 [ADD A DESCRIPTION OF THE MODEL HERE - see other MAX models for examples]
@@ -136,14 +136,14 @@ The API server automatically generates an interactive Swagger documentation page
 
 [INSERT DESCRIPTION OF HOW TO USE MODEL ENDPOINT]
 
-> Example description for image upload models: Use the `model/predict` endpoint to load a test image (you can use one of the test images from the `assets` folder) and get predicted labels for the image from the API.
+> Example description for image upload models: Use the `model/predict` endpoint to load a test image (you can use one of the test images from the `samples` folder) and get predicted labels for the image from the API.
 
 ![INSERT SWAGGER UI SCREENSHOT HERE](docs/swagger-screenshot.png)
 
 You can also test it on the command line, for example:
 
 ```
-$ curl -F "image=@assets/[SAMPLE IMAGE]" -XPOST http://localhost:5000/model/predict
+$ curl -F "image=@samples/[SAMPLE IMAGE]" -XPOST http://localhost:5000/model/predict
 ```
 
 You should see a JSON response like that below:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Clone the `MAX-skeleton` repository locally. In a terminal run the following com
 
     $ git clone https://github.com/IBM/MAX-Skeleton
 
-The project files are structured into 4 main parts: model, api, assets, and samples. The `model` directory will contain code used for loading the model and running the predictions. The `api` directory contains code to handle the inputs and outputs of the MAX microservice. The `assets` directory will contain model assets, whereas the `samples` directory will contain sample data and notebooks for the user to try the service.
+The project files are structured into three main parts: model, api, and samples. The `model` directory will contain code used for loading the model and running the predictions. The `api` directory contains code to handle the inputs and outputs of the MAX microservice. The `samples` directory will contain sample data and notebooks for the user to try the service.
 
 Example:
 ```
@@ -28,7 +28,6 @@ Example:
   api/
     metadata.py
     predict.py
-  assets/
 ```
 
 ### 2. Modify the Dockerfile
@@ -168,5 +167,4 @@ Copy the README files and add the relevant details for the specific model and us
 
 More specifically, update the following README files:
 - Replace this `README.md` file with the completed `README-template.md` file
-- Complete the `assets/README.md` file with information about the model assets
 - Complete the `samples/README.md` file with information about the data samples and the demo notebook, if any

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,9 +1,0 @@
-# Asset Details
-
-## Model files
-
-The model is based on the [ADD OPEN SOURCE MODEL]([LINK TO MODEL]) model, which is available and licensed under [LICENSE](LINK TO LICENSE). 
-
-> DISCUSS WHETHER THE MODEL IS RETRAINED OR FINETUNED
-
-_Note: the model files are hosted on [IBM Cloud Object Storage]([LINK TO MODEL FILES])._


### PR DESCRIPTION
There is no longer a need  to keep this "empty" placeholder directory:
- all model assets are stored on Cloud Object Storage (and the `assets/` directory is created on the fly when the model is built and populated using those assets)
- sample assets are stored in `samples/`